### PR TITLE
enable network w/ explicit contexts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,12 +63,8 @@
 mod network;
 mod proj;
 
-pub use crate::proj::enable_network;
-pub use crate::proj::get_url_endpoint;
-pub use crate::proj::grid_cache_set_enable;
-pub use crate::proj::network_enabled;
-pub use crate::proj::set_url_endpoint;
 pub use crate::proj::Area;
 pub use crate::proj::Proj;
+pub use crate::proj::ProjContext;
 pub use crate::proj::ProjError;
 pub use crate::proj::Projinfo;

--- a/src/network.rs
+++ b/src/network.rs
@@ -341,19 +341,3 @@ fn _network_read_range(
     hd.headers = headers;
     Ok(contentlength)
 }
-
-/// Set up and initialise the grid download callback functions for all subsequent PROJ contexts
-pub(crate) fn set_network_callbacks() -> i32 {
-    let ud: *mut c_void = ptr::null_mut();
-    let dctx: *mut PJ_CONTEXT = ptr::null_mut();
-    unsafe {
-        proj_context_set_network_callbacks(
-            dctx,
-            Some(network_open),
-            Some(network_close),
-            Some(network_get_header_value),
-            Some(network_read_range),
-            ud,
-        )
-    }
-}

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -698,21 +698,21 @@ mod test {
         assert_almost_eq(t.y(), 1141263.01);
     }
     // This test is disabled by default as it requires network access
-    // #[test]
-    // fn test_network() {
-    //     let from = "EPSG:4326";
-    //     let to = "EPSG:4326+3855";
-    //     // off by default
-    //     assert_eq!(network_enabled(), false);
-    //     // switch it on and disable cache for subsequent calls
-    //     grid_cache_set_enable(false);
-    //     enable_network(true).unwrap();
-    //     let proj = Proj::new_known_crs(&from, &to, None).unwrap();
-    //     assert_eq!(network_enabled(), true);
-    //     let t = proj.convert(Point::new(40.0, -80.0)).unwrap();
-    //     assert_almost_eq(t.x(), 39.99999839);
-    //     assert_almost_eq(t.y(), -79.99999807);
-    // }
+    #[test]
+    fn test_network() {
+        let from = "EPSG:4326";
+        let to = "EPSG:4326+3855";
+        // off by default
+        assert_eq!(network_enabled(), false);
+        // switch it on and disable cache for subsequent calls
+        grid_cache_set_enable(false);
+        enable_network(true).unwrap();
+        let proj = Proj::new_known_crs(&from, &to, None).unwrap();
+        assert_eq!(network_enabled(), true);
+        let t = proj.convert(Point::new(40.0, -80.0)).unwrap();
+        assert_almost_eq(t.x(), 39.99999839);
+        assert_almost_eq(t.y(), -79.99999807);
+    }
     #[test]
     // Carry out a projection from geodetic coordinates
     fn test_projection() {


### PR DESCRIPTION
Following up on our conversation here https://github.com/georust/proj/pull/34#discussion_r457271297 @urschrei 

> In order to create transformation / projection instances using the crate, you can call Proj::new / Proj::new_known_crs. Note that both of these methods first create a ctx – the implicit context creation was a design decision on my part because I thought it would be tedious to explicitly create e.g. a Context instance, then call a projection / transformation method on it.

> However, modifying search paths, network download functionality etc requires a ctx, as you point out – changing network download and search paths has to be done before the transformation / projection object is created, because their creation may require search path lookup or remote grid file download. But because there is now no access to a ctx independently of a Proj instance, these properties can't be modified for an existing instance: they have to be set before creation. So there are three choices:

> Break the API by requiring a two-step process: context creation followed by transformation / projection specification which consumes the ctx, with modification to search paths and network functionality as an intermediate step;
> Break the API by adding new arguments to Proj::new / Proj::new_known_crs`
> Leave the API as-is currently, which is at odds to the libproj API – my feeling is that crate users don't generally want or need to control these properties for concurrently existing Proj instances, and the existing effects of modifying properties are explicitly detailed in the comments.

My intuition is that you're right - the majority of users probably don't want to futz with explicit contexts, and so it makes sense to optimize for that use case. 

**ideally* we could do so while breaking as few assumptions as possible for the minority of users that actually *want* the explicit contexts. You've done a good job of caveating in the comments, but it'd of course be better still if we could prevent the users from shooting themselves in the foot by design (without making the API too arduous for the common case).

So... here's what I came to after messing around with your PR for a bit.

Do you think an API like this could be viable @urschrei?

A completely separate thought: I don't think that mutating the default context was thread safe (this PR doesn't change that). It might be nice to one day add our own synchronization around that.
